### PR TITLE
Fixed Router Refresh Problem

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,12 +1,14 @@
 env: standard
-runtime: nodejs12
+runtime: nodejs16
 service: default
 handlers:
-  - url: /
+  # Handle static files.
+  - url: /(.*\..+)$
+    static_files: dist/\1
+    upload: dist/(.*\..+)$
+    secure: always
+  # Catch all
+  - url: /.*
     static_files: dist/index.html
     upload: dist/index.html
-    secure: always
-
-  - url: /
-    static_dir: dist
     secure: always

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marktakatsuka",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marktakatsuka",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.2",
@@ -44,7 +44,7 @@
         "vuetify-loader": "^1.3.0"
       },
       "engines": {
-        "node": "12.x.x"
+        "node": "16.x.x"
       }
     },
     "node_modules/@amcharts/amcharts4": {


### PR DESCRIPTION
This PR close #41. First, the node runtime was updated from 12 to 16 in the app config. Additionally, the problem was with how the app config was serving the static pages. So, with this updated config, when the page is refreshed it re-loads the pre-loader and then resumes at that page without a 404.