### PR TITLE
Fix Scroll Nav-bar hiding on Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marktakatsuka",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marktakatsuka",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "animate.css": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marktakatsuka",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "author": "Mark Takatsuka",
   "license": "MIT",

--- a/src/components/Layout/Layout.vue
+++ b/src/components/Layout/Layout.vue
@@ -32,8 +32,12 @@ export default {
   },
   methods: {
     handleScroll() {
-      const { scrollY } = window;
-      this.show_navbar = scrollY <= this.last_y;
+      const scrollY = document.body.getBoundingClientRect().top;
+      if (scrollY > this.last_y || scrollY >= 0) {
+        this.show_navbar = true;
+      } else {
+        this.show_navbar = false;
+      }
       this.last_y = scrollY;
     },
   },


### PR DESCRIPTION
Closes #57 

This PR fixes the issue where the navbar will hide on safari devices since they will over-scroll.